### PR TITLE
Optimize compliments marquee animation performance

### DIFF
--- a/src/components/home/compliment/Compliments.js
+++ b/src/components/home/compliment/Compliments.js
@@ -117,6 +117,7 @@ function MarqueeRow({items, reverse = false, speed = 42}) {
     const rafRef = useRef(null);
     const lastInteractionRef = useRef(-AUTO_RESUME_DELAY);
     const scrollPositionRef = useRef(0);
+    const cardsRef = useRef([]);
 
     const getSegmentWidth = useCallback((scroller) => scroller.scrollWidth / LOOP_COPIES, []);
 
@@ -131,28 +132,34 @@ function MarqueeRow({items, reverse = false, speed = 42}) {
         }
     }, [getSegmentWidth]);
 
+    const collectCards = useCallback(() => {
+        const scroller = scrollerRef.current;
+        if (!scroller) return;
+
+        cardsRef.current = Array.from(scroller.querySelectorAll(".compliment-card")).map((card) => ({
+            el: card,
+            center: card.offsetLeft + card.offsetWidth / 2,
+        }));
+    }, []);
+
     const updateCardDepth = useCallback(() => {
         const scroller = scrollerRef.current;
         if (!scroller) return;
 
-        const scrollerRect = scroller.getBoundingClientRect();
-        const centerX = scrollerRect.left + scrollerRect.width / 2;
-        const maxDistance = scrollerRect.width * 0.58;
-        const cards = scroller.querySelectorAll(".compliment-card");
+        const centerX = scroller.scrollLeft + scroller.clientWidth / 2;
+        const maxDistance = scroller.clientWidth * 0.58;
 
-        cards.forEach((card) => {
-            const rect = card.getBoundingClientRect();
-            const cardCenterX = rect.left + rect.width / 2;
-            const offset = Math.max(-1, Math.min(1, (cardCenterX - centerX) / maxDistance));
+        cardsRef.current.forEach(({el, center}) => {
+            const offset = Math.max(-1, Math.min(1, (center - centerX) / maxDistance));
             const distance = Math.abs(offset);
             const translateZ = -distance * 280;
             const rotateY = offset * -34;
             const scale = 1 - distance * 0.18;
             const translateY = distance * 14;
 
-            card.style.transform = `translateZ(${translateZ}px) rotateY(${rotateY}deg) scale(${scale}) translateY(${translateY}px)`;
-            card.style.opacity = `${1 - distance * 0.12}`;
-            card.style.zIndex = `${Math.round((1 - distance) * 100)}`;
+            el.style.transform = `translateZ(${translateZ}px) rotateY(${rotateY}deg) scale(${scale}) translateY(${translateY}px)`;
+            el.style.opacity = `${1 - distance * 0.12}`;
+            el.style.zIndex = `${Math.round((1 - distance) * 100)}`;
         });
     }, []);
 
@@ -175,6 +182,7 @@ function MarqueeRow({items, reverse = false, speed = 42}) {
 
         const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
         const centerScroller = () => {
+            collectCards();
             scrollPositionRef.current = getSegmentWidth(scroller);
             scroller.scrollLeft = scrollPositionRef.current;
             updateCardDepth();
@@ -212,7 +220,7 @@ function MarqueeRow({items, reverse = false, speed = 42}) {
             window.cancelAnimationFrame(rafRef.current);
             window.removeEventListener("resize", centerScroller);
         };
-    }, [getSegmentWidth, resetLoopPosition, reverse, speed, updateCardDepth]);
+    }, [collectCards, getSegmentWidth, resetLoopPosition, reverse, speed, updateCardDepth]);
 
     return (
         <div className="marquee-row">

--- a/src/components/home/compliment/Compliments.js
+++ b/src/components/home/compliment/Compliments.js
@@ -118,6 +118,7 @@ function MarqueeRow({items, reverse = false, speed = 42}) {
     const lastInteractionRef = useRef(-AUTO_RESUME_DELAY);
     const scrollPositionRef = useRef(0);
     const cardsRef = useRef([]);
+    const depthRafRef = useRef(null);
 
     const getSegmentWidth = useCallback((scroller) => scroller.scrollWidth / LOOP_COPIES, []);
 
@@ -139,6 +140,9 @@ function MarqueeRow({items, reverse = false, speed = 42}) {
         cardsRef.current = Array.from(scroller.querySelectorAll(".compliment-card")).map((card) => ({
             el: card,
             center: card.offsetLeft + card.offsetWidth / 2,
+            transform: "",
+            opacity: "",
+            zIndex: "",
         }));
     }, []);
 
@@ -149,19 +153,40 @@ function MarqueeRow({items, reverse = false, speed = 42}) {
         const centerX = scroller.scrollLeft + scroller.clientWidth / 2;
         const maxDistance = scroller.clientWidth * 0.58;
 
-        cardsRef.current.forEach(({el, center}) => {
+        cardsRef.current.forEach((cardMeta) => {
+            const {el, center} = cardMeta;
             const offset = Math.max(-1, Math.min(1, (center - centerX) / maxDistance));
             const distance = Math.abs(offset);
             const translateZ = -distance * 280;
             const rotateY = offset * -34;
             const scale = 1 - distance * 0.18;
             const translateY = distance * 14;
+            const transform = `translateZ(${translateZ}px) rotateY(${rotateY}deg) scale(${scale}) translateY(${translateY}px)`;
+            const opacity = `${1 - distance * 0.12}`;
+            const zIndex = `${Math.round((1 - distance) * 100)}`;
 
-            el.style.transform = `translateZ(${translateZ}px) rotateY(${rotateY}deg) scale(${scale}) translateY(${translateY}px)`;
-            el.style.opacity = `${1 - distance * 0.12}`;
-            el.style.zIndex = `${Math.round((1 - distance) * 100)}`;
+            if (cardMeta.transform !== transform) {
+                cardMeta.transform = transform;
+                el.style.transform = transform;
+            }
+            if (cardMeta.opacity !== opacity) {
+                cardMeta.opacity = opacity;
+                el.style.opacity = opacity;
+            }
+            if (cardMeta.zIndex !== zIndex) {
+                cardMeta.zIndex = zIndex;
+                el.style.zIndex = zIndex;
+            }
         });
     }, []);
+
+    const scheduleDepthUpdate = useCallback(() => {
+        if (depthRafRef.current) return;
+        depthRafRef.current = window.requestAnimationFrame(() => {
+            depthRafRef.current = null;
+            updateCardDepth();
+        });
+    }, [updateCardDepth]);
 
     const pauseForUserScroll = useCallback(() => {
         lastInteractionRef.current = window.performance.now();
@@ -173,8 +198,8 @@ function MarqueeRow({items, reverse = false, speed = 42}) {
 
         resetLoopPosition(scroller);
         scrollPositionRef.current = scroller.scrollLeft;
-        updateCardDepth();
-    }, [resetLoopPosition, updateCardDepth]);
+        scheduleDepthUpdate();
+    }, [resetLoopPosition, scheduleDepthUpdate]);
 
     useEffect(() => {
         const scroller = scrollerRef.current;
@@ -206,7 +231,7 @@ function MarqueeRow({items, reverse = false, speed = 42}) {
                 }
 
                 scroller.scrollLeft = scrollPositionRef.current;
-                updateCardDepth();
+                scheduleDepthUpdate();
             }
 
             rafRef.current = window.requestAnimationFrame(animate);
@@ -218,9 +243,10 @@ function MarqueeRow({items, reverse = false, speed = 42}) {
 
         return () => {
             window.cancelAnimationFrame(rafRef.current);
+            window.cancelAnimationFrame(depthRafRef.current);
             window.removeEventListener("resize", centerScroller);
         };
-    }, [collectCards, getSegmentWidth, resetLoopPosition, reverse, speed, updateCardDepth]);
+    }, [collectCards, getSegmentWidth, resetLoopPosition, reverse, scheduleDepthUpdate, speed, updateCardDepth]);
 
     return (
         <div className="marquee-row">


### PR DESCRIPTION
### Motivation
- The bottom compliments marquee was feeling laggy because the depth/parallax code measured each card layout every animation frame, causing layout thrashing and jank. 
- The goal was to reduce per-frame layout work while keeping the existing visual design and 3D card effects.

### Description
- Added `cardsRef` and a `collectCards` function to cache card DOM references and their center positions so geometry is not re-measured on every frame. 
- Reworked `updateCardDepth` to use the cached centers and `scrollLeft`/`clientWidth` for faster per-frame math instead of calling `getBoundingClientRect` repeatedly. 
- Call `collectCards` on center/recenter and include it in the effect dependencies so cached geometry is refreshed on resize/initialization. 
- Preserved existing marquee looping, interaction pause logic, and visual transform calculations (translateZ/rotateY/scale/opacity) so the UI design is unchanged.

### Testing
- Ran `npm run lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2a0a2cfd48330a032d60fc7169496)